### PR TITLE
Adding quantum-engine-uri to glossary

### DIFF
--- a/intro/content/basics/glossary.md
+++ b/intro/content/basics/glossary.md
@@ -19,3 +19,4 @@ description: A list of helpful definitions for Orquestra
 - `Workflow Parameter`: A parameter which can be referred to anywhere inside of the workflow. 
 - `Entrypoint`: The template that is called when the workflow begins.
 - `generateName`: A string that is used as a prefix for the generation of the `workflowID` and `stepID`'s associated with the given workflow.
+- `quantum-engine-uri`: A link to the server where your `Quantum Engine` is


### PR DESCRIPTION
There are always a lot of questions about "what is my `quantum-engine-uri`" so I think having more information in more locations about it would be better :)