### PR TITLE
[#174674938] Add doc for ssh-agent-activate.sh

### DIFF
--- a/v1/content/qe-cli/install-cli.md
+++ b/v1/content/qe-cli/install-cli.md
@@ -62,8 +62,8 @@ sudo cp ./qe /usr/local/bin/
 ### Notes
 If the above scripts do not work, you can download `qe` from [github](https://github.com/zapatacomputing/qe-cli/releases/latest) as a binary. There are individual download links for common platforms.
 ds
-#### ssh-agent
-On some OS platforms, ssh-agent changes do not persist across different shell sessions; consequently you may need to add the same key in different shell sessions using `ssh-add -k` all over again.
+#### ssh-agent and ssh keys
+On some OS platforms, `ssh-agent` changes do not persist across different shell sessions; consequently you may need to add the same key in different shell sessions using `ssh-add -k` all over again.
 
 To remedy this, you may incorporate the following script `ssh-agent-activate.sh` into your shell startup script.
 

--- a/v1/content/qe-cli/install-cli.md
+++ b/v1/content/qe-cli/install-cli.md
@@ -61,3 +61,16 @@ sudo cp ./qe /usr/local/bin/
 
 ### Notes
 If the above scripts do not work, you can download `qe` from [github](https://github.com/zapatacomputing/qe-cli/releases/latest) as a binary. There are individual download links for common platforms.
+ds
+#### ssh-agent
+On some OS platforms, ssh-agent changes do not persist across different shell sessions; consequently you may need to add the same key in different shell sessions using `ssh-add -k` all over again.
+
+To remedy this, you may incorporate the following script `ssh-agent-activate.sh` into your shell startup script.
+
+Example for Bash shells:
+
+```Bash
+echo 'source ~/qe/bin/ssh-agent-activate.sh' >> ~/.bashrc
+```
+
+


### PR DESCRIPTION
Signed-off-by: BK Lau <bk.lau@zapatacomputing.com>
Document the use of ssh-agent-activate.sh to prevent unnecessary instances of ssh-agent when running multiple ssh-add commands across different shell session. Parent story [#174626153]
